### PR TITLE
Fix badge spacing and card height

### DIFF
--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -43,9 +43,9 @@ const TaskCard: React.FC<TaskCardProps> = ({ task }) => {
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.95 }}
         transition={{ type: "spring", stiffness: 400, damping: 25 }}
-        className="relative"
+        className="relative h-full"
       >
-        <Card>
+        <Card className="h-full">
           <CardContent>
             <div className="flex items-start gap-4">
               <div className="flex-1 overflow-hidden">
@@ -65,7 +65,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task }) => {
                     {task.description}
                   </p>
                 )}
-                <div className="mt-4 flex flex-wrap space-x-2">
+                <div className="mt-4 flex flex-wrap gap-2">
                   {task.category && (
                     <Badge variant="outline">{task.category}</Badge>
                   )}

--- a/src/components/task-container.tsx
+++ b/src/components/task-container.tsx
@@ -99,7 +99,7 @@ const TaskContainer: React.FC<TaskContainerProps> = ({ title, group }) => {
         <div
           className={
             displayMode === "grid"
-              ? "grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3"
+              ? "grid auto-rows-fr grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3"
               : "space-y-3"
           }
         >


### PR DESCRIPTION
## Summary
- allow wrapping badges to have vertical spacing
- make task cards stretch to fill grid rows
- use equal-height auto rows for tasks in grid mode

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @tanstack/eslint-config)*
- `npm run format` *(fails: cannot find prettier plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684e0af3d1048326b3c6a6714289b27a